### PR TITLE
Do not include time for `scrot` to run in delay between screenshots.

### DIFF
--- a/glapseControllers/glapseMain.py
+++ b/glapseControllers/glapseMain.py
@@ -92,7 +92,7 @@ class GlapseMain:
             fileName = "%09d" % (self.currentShot)
             fileName = fileName + '.jpg'
             
-            command = 'scrot -q ' + str(self.quality) + ' ' + self.outputDir + os.sep + fileName
+            command = 'scrot -q ' + str(self.quality) + ' ' + self.outputDir + os.sep + fileName + " &"
             
             print 'Taking screenshot: ' + command + '...'
             


### PR DESCRIPTION
With interval set on 1, I noticed that there seemed to be more than a second delay between screenshots.
I then ran `time scrot` and got this:

```
scrot  0.23s user 0.00s system 67% cpu 0.352 total
```

This quick fix removes this time from the delay between screenshots.
