### PR TITLE
Use of python2 for the bin

### DIFF
--- a/glapse
+++ b/glapse
@@ -2,4 +2,4 @@
 
 cd /usr/lib/glapse/
 
-python glapse.py
+python2 glapse.py


### PR DESCRIPTION
This uses gtk libraries for python2 and breaks using python3.4.
I cant see an advantage to using the default env over python2